### PR TITLE
Fix directory entry sorting bug

### DIFF
--- a/packages/sandbox/src/utils/readDirEnts.ts
+++ b/packages/sandbox/src/utils/readDirEnts.ts
@@ -6,14 +6,11 @@ import type { WebContainer } from '@webcontainer/api'
  * @param container
  * @param path
  */
-export const readDirEnts = async (container: WebContainer, path: string) =>
-  (
-    await container.fs.readdir(path, {
-      withFileTypes: true,
-    })
-  ).sort((a, b) => {
-    if (a.isDirectory() && b.isFile()) {
-      return -1
-    }
-    return 0
+export const readDirEnts = async (container: WebContainer, path: string) => {
+  const ents = await container.fs.readdir(path, { withFileTypes: true })
+  return ents.sort((a, b) => {
+    if (a.isDirectory() && b.isFile()) return -1
+    if (a.isFile() && b.isDirectory()) return 1
+    return a.name.localeCompare(b.name)
   })
+}


### PR DESCRIPTION
## Summary
- correct sort logic in `readDirEnts`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/compat')*

------
https://chatgpt.com/codex/tasks/task_e_6854066453208325b0483f1e1de5cb0d