### PR TITLE
Fix locale-prefixed content path handling across docs

### DIFF
--- a/apps/docs/components/docs/breadcrumb/Breadcrumb.vue
+++ b/apps/docs/components/docs/breadcrumb/Breadcrumb.vue
@@ -7,16 +7,19 @@ import {
   BreadcrumbSeparator,
 } from '~/components/ui/breadcrumb'
 
-const { t } = useI18n()
-const route = useRouter().currentRoute
+const { t, locale } = useI18n()
 const queryLocalisedCollection = useLocalisedCollection()
+const contentPath = useContentPath()
 
 const fetchBreadcrumb = () => {
+  // Build step paths from the locale-prefixed content path, then skip the
+  // bare locale root (e.g. /en) – it's not a meaningful breadcrumb segment.
+  const localeRoot = `/${locale.value}`
   return Promise.all(
-    route.value.path
+    contentPath.value
       .split('/')
       .map((_, idx, parts) => parts.slice(0, idx + 1).join('/'))
-      .filter((stepPath) => stepPath)
+      .filter((stepPath) => stepPath && stepPath !== localeRoot)
       .map((stepPath) =>
         queryLocalisedCollection((builder) =>
           builder
@@ -38,7 +41,7 @@ const fetchBreadcrumb = () => {
 }
 
 const { data: breadcrumb } = await useAsyncData(fetchBreadcrumb, {
-  watch: [() => route.value.path],
+  watch: [contentPath],
 })
 </script>
 

--- a/apps/docs/components/docs/not-found/NotFound.vue
+++ b/apps/docs/components/docs/not-found/NotFound.vue
@@ -2,17 +2,19 @@
 import { fallbackTitleKey } from '~/utils/fallbackTitleKey'
 
 const { t } = useI18n()
-const route = useRouter().currentRoute
-const pathParts = computed(() => route.value.path.split('/'))
+const route = useRoute()
+const pathParts = computed(() => route.path.split('/'))
 
 const titleKey = computed(() => fallbackTitleKey(pathParts.value))
 
 const queryLocalisedCollectionNavigation = useLocalisedCollectionNavigation()
+const contentPath = useContentPath()
 
 const { data: result } = await useAsyncData(() =>
   queryLocalisedCollectionNavigation((builder) =>
-    builder.where('path', 'LIKE', `${route.value.path}%`),
+    builder.where('path', 'LIKE', `${contentPath.value}%`),
   ),
+  { watch: [contentPath] },
 )
 
 const list = computed(() => {

--- a/apps/docs/components/docs/side-bar/SideBar.vue
+++ b/apps/docs/components/docs/side-bar/SideBar.vue
@@ -36,17 +36,18 @@ const bottomPath = computed(() =>
 )
 
 const { data: topNav } = await useAsyncData(
-  () => `sidebar-top-${topPath.value}`,
+  `sidebar-top-${topPath.value}`,
   () =>
     topPath.value
       ? queryLocalisedCollectionNavigation((builder) =>
           builder.where('path', 'LIKE', `${topPath.value}%`),
         )
       : Promise.resolve(null),
+  { watch: [topPath] },
 )
 
 const { data: bottomNav } = await useAsyncData(
-  () => `sidebar-bottom-${bottomPath.value}`,
+  `sidebar-bottom-${bottomPath.value}`,
   () =>
     bottomPath.value
       ? queryLocalisedCollectionNavigation((builder) =>
@@ -55,6 +56,7 @@ const { data: bottomNav } = await useAsyncData(
             .where('id', 'NOT LIKE', '%index.md'),
         )
       : Promise.resolve(null),
+  { watch: [bottomPath] },
 )
 
 const getTitle = async (path?: string) => {
@@ -72,13 +74,15 @@ const getTitle = async (path?: string) => {
 }
 
 const { data: topTitle } = useAsyncData(
-  () => `sidebar-top-title-${topPath.value}`,
+  `sidebar-top-title-${topPath.value}`,
   () => getTitle(topPath.value),
+  { watch: [topPath] },
 )
 
 const { data: bottomTitle } = useAsyncData(
-  () => `sidebar-bottom-title-${bottomPath.value}`,
+  `sidebar-bottom-title-${bottomPath.value}`,
   () => getTitle(bottomPath.value),
+  { watch: [bottomPath] },
 )
 </script>
 

--- a/apps/docs/components/docs/side-bar/SideBar.vue
+++ b/apps/docs/components/docs/side-bar/SideBar.vue
@@ -36,20 +36,17 @@ const bottomPath = computed(() =>
 )
 
 const { data: topNav } = await useAsyncData(
-  `sidebar-top-${topPath.value}`,
+  () => `sidebar-top-${topPath.value}`,
   () =>
     topPath.value
       ? queryLocalisedCollectionNavigation((builder) =>
           builder.where('path', 'LIKE', `${topPath.value}%`),
         )
       : Promise.resolve(null),
-  {
-    watch: [topPath],
-  },
 )
 
 const { data: bottomNav } = await useAsyncData(
-  `sidebar-bottom-${bottomPath.value}`,
+  () => `sidebar-bottom-${bottomPath.value}`,
   () =>
     bottomPath.value
       ? queryLocalisedCollectionNavigation((builder) =>
@@ -58,9 +55,6 @@ const { data: bottomNav } = await useAsyncData(
             .where('id', 'NOT LIKE', '%index.md'),
         )
       : Promise.resolve(null),
-  {
-    watch: [bottomPath],
-  },
 )
 
 const getTitle = async (path?: string) => {
@@ -78,19 +72,13 @@ const getTitle = async (path?: string) => {
 }
 
 const { data: topTitle } = useAsyncData(
-  `sidebar-top-title-${topPath.value}`,
+  () => `sidebar-top-title-${topPath.value}`,
   () => getTitle(topPath.value),
-  {
-    watch: [topPath],
-  },
 )
 
 const { data: bottomTitle } = useAsyncData(
-  `sidebar-bottom-title-${bottomPath.value}`,
+  () => `sidebar-bottom-title-${bottomPath.value}`,
   () => getTitle(bottomPath.value),
-  {
-    watch: [bottomPath],
-  },
 )
 </script>
 

--- a/apps/docs/components/docs/side-bar/SideBar.vue
+++ b/apps/docs/components/docs/side-bar/SideBar.vue
@@ -1,19 +1,38 @@
 <script setup lang="ts">
 import { fallbackTitleKey } from '~/utils/fallbackTitleKey'
 
-const { t } = useI18n()
-const route = useRouter().currentRoute
+const { t, locale } = useI18n()
 const queryLocalisedCollection = useLocalisedCollection()
 const queryLocalisedCollectionNavigation = useLocalisedCollectionNavigation()
+const contentPath = useContentPath()
 
-const pathParts = computed(() => route.value.path.split('/').slice(0, 3))
+// Strip the locale prefix so the 2-level hierarchy (/section/page) is
+// computed the same way regardless of whether the URL has a locale prefix.
+const localePrefix = computed(() => `/${locale.value}`)
+const localPath = computed(() => {
+  const p = contentPath.value
+  if (p.startsWith(`${localePrefix.value}/`)) return p.slice(localePrefix.value.length)
+  if (p === localePrefix.value) return '/'
+  return p
+})
+
+// Re-add the locale prefix for the actual DB queries.
+const toContentPath = (localSegmentPath: string) => {
+  const pre = localePrefix.value
+  if (!localSegmentPath || localSegmentPath === '/') return pre
+  if (localSegmentPath.startsWith(`${pre}/`) || localSegmentPath === pre)
+    return localSegmentPath
+  return `${pre}${localSegmentPath}`
+}
+
+const pathParts = computed(() => localPath.value.split('/').slice(0, 3))
 const topPath = computed(() =>
   2 <= pathParts.value.length
-    ? pathParts.value.slice(0, 2).join('/')
+    ? toContentPath(pathParts.value.slice(0, 2).join('/') || '/')
     : undefined,
 )
 const bottomPath = computed(() =>
-  3 === pathParts.value.length ? pathParts.value.join('/') : undefined,
+  3 === pathParts.value.length ? toContentPath(pathParts.value.join('/')) : undefined,
 )
 
 const { data: topNav } = await useAsyncData(

--- a/apps/docs/components/docs/side-bar/SideBar.vue
+++ b/apps/docs/components/docs/side-bar/SideBar.vue
@@ -43,7 +43,9 @@ const { data: topNav } = await useAsyncData(
           builder.where('path', 'LIKE', `${topPath.value}%`),
         )
       : Promise.resolve(null),
-  { watch: [topPath] },
+  {
+    watch: [topPath],
+  },
 )
 
 const { data: bottomNav } = await useAsyncData(
@@ -56,7 +58,9 @@ const { data: bottomNav } = await useAsyncData(
             .where('id', 'NOT LIKE', '%index.md'),
         )
       : Promise.resolve(null),
-  { watch: [bottomPath] },
+  {
+    watch: [bottomPath],
+  },
 )
 
 const getTitle = async (path?: string) => {
@@ -76,13 +80,17 @@ const getTitle = async (path?: string) => {
 const { data: topTitle } = useAsyncData(
   `sidebar-top-title-${topPath.value}`,
   () => getTitle(topPath.value),
-  { watch: [topPath] },
+  {
+    watch: [topPath],
+  },
 )
 
 const { data: bottomTitle } = useAsyncData(
   `sidebar-bottom-title-${bottomPath.value}`,
   () => getTitle(bottomPath.value),
-  { watch: [bottomPath] },
+  {
+    watch: [bottomPath],
+  },
 )
 </script>
 

--- a/apps/docs/components/docs/toc/TOCResponsive.vue
+++ b/apps/docs/components/docs/toc/TOCResponsive.vue
@@ -5,9 +5,10 @@ const { t } = useI18n()
 const queryLocalisedCollection = useLocalisedCollection()
 const contentPath = useContentPath()
 const { data: page } = await useAsyncData(
-  () => contentPath.value,
+  contentPath.value,
   () => queryLocalisedCollection((builder) => builder.path(contentPath.value).first()),
   {
+    watch: [contentPath],
     getCachedData(key, nuxtApp) {
       const cached = nuxtApp.payload.data[key]
       return cached?.body ? cached : undefined

--- a/apps/docs/components/docs/toc/TOCResponsive.vue
+++ b/apps/docs/components/docs/toc/TOCResponsive.vue
@@ -5,12 +5,14 @@ const { t } = useI18n()
 const queryLocalisedCollection = useLocalisedCollection()
 const contentPath = useContentPath()
 const { data: page } = await useAsyncData(
-  contentPath.value,
-  () =>
-    queryLocalisedCollection((builder) =>
-      builder.path(contentPath.value).first(),
-    ),
-  { watch: [contentPath] },
+  () => contentPath.value,
+  () => queryLocalisedCollection((builder) => builder.path(contentPath.value).first()),
+  {
+    getCachedData(key, nuxtApp) {
+      const cached = nuxtApp.payload.data[key]
+      return cached?.body ? cached : undefined
+    },
+  },
 )
 const toc = computed(() => page.value?.body?.toc)
 const tocIsOpen = ref(false)

--- a/apps/docs/components/docs/toc/TOCResponsive.vue
+++ b/apps/docs/components/docs/toc/TOCResponsive.vue
@@ -1,16 +1,16 @@
 <script setup lang="ts">
 import { Button, ScrollArea } from '@karagoz/shared'
 
-const route = useRouter().currentRoute
 const { t } = useI18n()
 const queryLocalisedCollection = useLocalisedCollection()
+const contentPath = useContentPath()
 const { data: page } = await useAsyncData(
-  route.value.path,
+  contentPath.value,
   () =>
     queryLocalisedCollection((builder) =>
-      builder.path(route.value.path).first(),
+      builder.path(contentPath.value).first(),
     ),
-  { watch: [() => route.value.path] },
+  { watch: [contentPath] },
 )
 const toc = computed(() => page.value?.body?.toc)
 const tocIsOpen = ref(false)

--- a/apps/docs/components/docs/toc/TOCResponsive.vue
+++ b/apps/docs/components/docs/toc/TOCResponsive.vue
@@ -6,14 +6,11 @@ const queryLocalisedCollection = useLocalisedCollection()
 const contentPath = useContentPath()
 const { data: page } = await useAsyncData(
   contentPath.value,
-  () => queryLocalisedCollection((builder) => builder.path(contentPath.value).first()),
-  {
-    watch: [contentPath],
-    getCachedData(key, nuxtApp) {
-      const cached = nuxtApp.payload.data[key]
-      return cached?.body ? cached : undefined
-    },
-  },
+  () =>
+    queryLocalisedCollection((builder) =>
+      builder.path(contentPath.value).first(),
+    ),
+  { watch: [contentPath] },
 )
 const toc = computed(() => page.value?.body?.toc)
 const tocIsOpen = ref(false)

--- a/apps/docs/composables/useContentPath.ts
+++ b/apps/docs/composables/useContentPath.ts
@@ -1,0 +1,26 @@
+/**
+ * Returns a computed ref that converts the current route path into the
+ * locale-prefixed content path used by the @nuxt/content collections.
+ *
+ * Content is stored under locale-prefixed paths (e.g. /en/sandbox/setup)
+ * because the collection source includes the locale directory
+ * (`include: 'en/**'`). The default locale is served without a URL prefix
+ * by @nuxtjs/i18n (`prefix_and_default` strategy), so route.path for an
+ * English page is `/sandbox/setup` while the DB entry is `/en/sandbox/setup`.
+ * This composable bridges that gap.
+ */
+export const useContentPath = () => {
+  const { locale } = useI18n()
+  const route = useRoute()
+
+  return computed(() => {
+    const path = route.path
+    const prefix = `/${locale.value}`
+    // Already has the correct locale prefix – use as-is.
+    if (path === prefix || path.startsWith(`${prefix}/`)) return path
+    // Root path maps to the locale root (e.g. / → /en).
+    if (path === '/' || path === '') return prefix
+    // Otherwise prepend the locale prefix.
+    return `${prefix}${path}`
+  })
+}

--- a/apps/docs/layouts/docs.vue
+++ b/apps/docs/layouts/docs.vue
@@ -3,15 +3,15 @@ import { ScrollArea } from '@karagoz/shared'
 
 import DefaultLayout from '~/layouts/default.vue'
 
-const route = useRouter().currentRoute
 const queryLocalisedCollection = useLocalisedCollection()
+const contentPath = useContentPath()
 const { data: page } = await useAsyncData(
-  route.value.path,
+  contentPath.value,
   () =>
     queryLocalisedCollection((builder) =>
-      builder.path(route.value.path).first(),
+      builder.path(contentPath.value).first(),
     ),
-  { watch: [() => route.value.path] },
+  { watch: [contentPath] },
 )
 
 const hideToc = computed(() => !page.value || page.value.hideToc)

--- a/apps/docs/layouts/docs.vue
+++ b/apps/docs/layouts/docs.vue
@@ -6,12 +6,14 @@ import DefaultLayout from '~/layouts/default.vue'
 const queryLocalisedCollection = useLocalisedCollection()
 const contentPath = useContentPath()
 const { data: page } = await useAsyncData(
-  contentPath.value,
-  () =>
-    queryLocalisedCollection((builder) =>
-      builder.path(contentPath.value).first(),
-    ),
-  { watch: [contentPath] },
+  () => contentPath.value,
+  () => queryLocalisedCollection((builder) => builder.path(contentPath.value).first()),
+  {
+    getCachedData(key, nuxtApp) {
+      const cached = nuxtApp.payload.data[key]
+      return cached?.body ? cached : undefined
+    },
+  },
 )
 
 const hideToc = computed(() => !page.value || page.value.hideToc)

--- a/apps/docs/layouts/docs.vue
+++ b/apps/docs/layouts/docs.vue
@@ -7,14 +7,11 @@ const queryLocalisedCollection = useLocalisedCollection()
 const contentPath = useContentPath()
 const { data: page } = await useAsyncData(
   contentPath.value,
-  () => queryLocalisedCollection((builder) => builder.path(contentPath.value).first()),
-  {
-    watch: [contentPath],
-    getCachedData(key, nuxtApp) {
-      const cached = nuxtApp.payload.data[key]
-      return cached?.body ? cached : undefined
-    },
-  },
+  () =>
+    queryLocalisedCollection((builder) =>
+      builder.path(contentPath.value).first(),
+    ),
+  { watch: [contentPath] },
 )
 
 const hideToc = computed(() => !page.value || page.value.hideToc)

--- a/apps/docs/layouts/docs.vue
+++ b/apps/docs/layouts/docs.vue
@@ -6,9 +6,10 @@ import DefaultLayout from '~/layouts/default.vue'
 const queryLocalisedCollection = useLocalisedCollection()
 const contentPath = useContentPath()
 const { data: page } = await useAsyncData(
-  () => contentPath.value,
+  contentPath.value,
   () => queryLocalisedCollection((builder) => builder.path(contentPath.value).first()),
   {
+    watch: [contentPath],
     getCachedData(key, nuxtApp) {
       const cached = nuxtApp.payload.data[key]
       return cached?.body ? cached : undefined

--- a/apps/docs/nuxt.config.ts
+++ b/apps/docs/nuxt.config.ts
@@ -107,7 +107,7 @@ export default defineNuxtConfig({
     },
     preset: 'cloudflare_module',
     routeRules: {
-      '/**': { ssr: true }, // Ensures SSR works for all routes
+      '/:pathMatch(.*)*': { ssr: true }, // Ensures SSR works for all routes
     },
     scanDirs: ['server'],
   },

--- a/apps/docs/nuxt.config.ts
+++ b/apps/docs/nuxt.config.ts
@@ -88,11 +88,11 @@ export default defineNuxtConfig({
   },
 
   modules: [
+    '@nuxthub/core',
     '@nuxt/content',
     '@nuxtjs/i18n',
     '@nuxtjs/tailwindcss',
     'shadcn-nuxt',
-    '@nuxthub/core',
   ],
 
   nitro: {

--- a/apps/docs/nuxt.config.ts
+++ b/apps/docs/nuxt.config.ts
@@ -107,7 +107,7 @@ export default defineNuxtConfig({
     },
     preset: 'cloudflare_module',
     routeRules: {
-      '/:pathMatch(.*)*': { ssr: true }, // Ensures SSR works for all routes
+      '/**': { ssr: true }, // Ensures SSR works for all routes
     },
     scanDirs: ['server'],
   },

--- a/apps/docs/pages/[...slug].vue
+++ b/apps/docs/pages/[...slug].vue
@@ -6,13 +6,20 @@ definePageMeta({
 const queryLocalisedCollection = useLocalisedCollection()
 const contentPath = useContentPath()
 
-const { data: page } = await useAsyncData(contentPath.value, () => {
-  return queryLocalisedCollection((builder) => builder.path(contentPath.value).first())
-}, { watch: [contentPath] })
+const { data: page } = await useAsyncData(
+  () => contentPath.value,
+  () => queryLocalisedCollection((builder) => builder.path(contentPath.value).first()),
+  {
+    getCachedData(key, nuxtApp) {
+      const cached = nuxtApp.payload.data[key]
+      return cached?.body ? cached : undefined
+    },
+  },
+)
 </script>
 
 <template>
-  <ContentRenderer v-if="page" :value="page" />
+  <ContentRenderer v-if="page?.body" :value="page" />
   <div v-else class="container">
     <div class="mx-auto py-6 lg:py-8 prose dark:prose-invert">
       <DocsNotFound />

--- a/apps/docs/pages/[...slug].vue
+++ b/apps/docs/pages/[...slug].vue
@@ -6,20 +6,13 @@ definePageMeta({
 const queryLocalisedCollection = useLocalisedCollection()
 const contentPath = useContentPath()
 
-const { data: page } = await useAsyncData(
-  contentPath.value,
-  () => queryLocalisedCollection((builder) => builder.path(contentPath.value).first()),
-  {
-    getCachedData(key, nuxtApp) {
-      const cached = nuxtApp.payload.data[key]
-      return cached?.body ? cached : undefined
-    },
-  },
-)
+const { data: page } = await useAsyncData(contentPath.value, () => {
+  return queryLocalisedCollection((builder) => builder.path(contentPath.value).first())
+}, { watch: [contentPath] })
 </script>
 
 <template>
-  <ContentRenderer v-if="page?.body" :value="page" />
+  <ContentRenderer v-if="page" :value="page" />
   <div v-else class="container">
     <div class="mx-auto py-6 lg:py-8 prose dark:prose-invert">
       <DocsNotFound />

--- a/apps/docs/pages/[...slug].vue
+++ b/apps/docs/pages/[...slug].vue
@@ -3,12 +3,12 @@ definePageMeta({
   layout: 'landing',
 })
 
-const route = useRoute()
 const queryLocalisedCollection = useLocalisedCollection()
+const contentPath = useContentPath()
 
-const { data: page } = await useAsyncData(route.path, () => {
-  return queryLocalisedCollection((builder) => builder.path(route.path).first())
-})
+const { data: page } = await useAsyncData(contentPath.value, () => {
+  return queryLocalisedCollection((builder) => builder.path(contentPath.value).first())
+}, { watch: [contentPath] })
 </script>
 
 <template>

--- a/apps/docs/pages/[...slug].vue
+++ b/apps/docs/pages/[...slug].vue
@@ -7,7 +7,7 @@ const queryLocalisedCollection = useLocalisedCollection()
 const contentPath = useContentPath()
 
 const { data: page } = await useAsyncData(
-  () => contentPath.value,
+  contentPath.value,
   () => queryLocalisedCollection((builder) => builder.path(contentPath.value).first()),
   {
     getCachedData(key, nuxtApp) {

--- a/apps/docs/pages/sandbox/[...slug].vue
+++ b/apps/docs/pages/sandbox/[...slug].vue
@@ -6,12 +6,19 @@ definePageMeta({
 const queryLocalisedCollection = useLocalisedCollection()
 const contentPath = useContentPath()
 
-const { data: page } = await useAsyncData(contentPath.value, () => {
-  return queryLocalisedCollection((builder) => builder.path(contentPath.value).first())
-}, { watch: [contentPath] })
+const { data: page } = await useAsyncData(
+  () => contentPath.value,
+  () => queryLocalisedCollection((builder) => builder.path(contentPath.value).first()),
+  {
+    getCachedData(key, nuxtApp) {
+      const cached = nuxtApp.payload.data[key]
+      return cached?.body ? cached : undefined
+    },
+  },
+)
 </script>
 
 <template>
-  <ContentRenderer v-if="page" :value="page"> </ContentRenderer>
+  <ContentRenderer v-if="page?.body" :value="page"> </ContentRenderer>
   <DocsNotFound v-else />
 </template>

--- a/apps/docs/pages/sandbox/[...slug].vue
+++ b/apps/docs/pages/sandbox/[...slug].vue
@@ -6,19 +6,12 @@ definePageMeta({
 const queryLocalisedCollection = useLocalisedCollection()
 const contentPath = useContentPath()
 
-const { data: page } = await useAsyncData(
-  contentPath.value,
-  () => queryLocalisedCollection((builder) => builder.path(contentPath.value).first()),
-  {
-    getCachedData(key, nuxtApp) {
-      const cached = nuxtApp.payload.data[key]
-      return cached?.body ? cached : undefined
-    },
-  },
-)
+const { data: page } = await useAsyncData(contentPath.value, () => {
+  return queryLocalisedCollection((builder) => builder.path(contentPath.value).first())
+}, { watch: [contentPath] })
 </script>
 
 <template>
-  <ContentRenderer v-if="page?.body" :value="page"> </ContentRenderer>
+  <ContentRenderer v-if="page" :value="page"> </ContentRenderer>
   <DocsNotFound v-else />
 </template>

--- a/apps/docs/pages/sandbox/[...slug].vue
+++ b/apps/docs/pages/sandbox/[...slug].vue
@@ -3,12 +3,12 @@ definePageMeta({
   layout: 'docs',
 })
 
-const route = useRoute()
 const queryLocalisedCollection = useLocalisedCollection()
+const contentPath = useContentPath()
 
-const { data: page } = await useAsyncData(route.path, () => {
-  return queryLocalisedCollection((builder) => builder.path(route.path).first())
-})
+const { data: page } = await useAsyncData(contentPath.value, () => {
+  return queryLocalisedCollection((builder) => builder.path(contentPath.value).first())
+}, { watch: [contentPath] })
 </script>
 
 <template>

--- a/apps/docs/pages/sandbox/[...slug].vue
+++ b/apps/docs/pages/sandbox/[...slug].vue
@@ -7,7 +7,7 @@ const queryLocalisedCollection = useLocalisedCollection()
 const contentPath = useContentPath()
 
 const { data: page } = await useAsyncData(
-  () => contentPath.value,
+  contentPath.value,
   () => queryLocalisedCollection((builder) => builder.path(contentPath.value).first()),
   {
     getCachedData(key, nuxtApp) {

--- a/apps/docs/pages/util/[...slug].vue
+++ b/apps/docs/pages/util/[...slug].vue
@@ -6,13 +6,20 @@ definePageMeta({
 const queryLocalisedCollection = useLocalisedCollection()
 const contentPath = useContentPath()
 
-const { data: page } = await useAsyncData(contentPath.value, () => {
-  return queryLocalisedCollection((builder) => builder.path(contentPath.value).first())
-}, { watch: [contentPath] })
+const { data: page } = await useAsyncData(
+  () => contentPath.value,
+  () => queryLocalisedCollection((builder) => builder.path(contentPath.value).first()),
+  {
+    getCachedData(key, nuxtApp) {
+      const cached = nuxtApp.payload.data[key]
+      return cached?.body ? cached : undefined
+    },
+  },
+)
 </script>
 
 <template>
-  <ContentRenderer v-if="page" :value="page" />
+  <ContentRenderer v-if="page?.body" :value="page" />
   <div v-else class="container">
     <div class="mx-auto py-6 lg:py-8 prose dark:prose-invert">
       <DocsNotFound />

--- a/apps/docs/pages/util/[...slug].vue
+++ b/apps/docs/pages/util/[...slug].vue
@@ -3,12 +3,12 @@ definePageMeta({
   layout: 'util',
 })
 
-const route = useRoute()
 const queryLocalisedCollection = useLocalisedCollection()
+const contentPath = useContentPath()
 
-const { data: page } = await useAsyncData(route.path, () => {
-  return queryLocalisedCollection((builder) => builder.path(route.path).first())
-})
+const { data: page } = await useAsyncData(contentPath.value, () => {
+  return queryLocalisedCollection((builder) => builder.path(contentPath.value).first())
+}, { watch: [contentPath] })
 </script>
 
 <template>

--- a/apps/docs/pages/util/[...slug].vue
+++ b/apps/docs/pages/util/[...slug].vue
@@ -6,20 +6,13 @@ definePageMeta({
 const queryLocalisedCollection = useLocalisedCollection()
 const contentPath = useContentPath()
 
-const { data: page } = await useAsyncData(
-  contentPath.value,
-  () => queryLocalisedCollection((builder) => builder.path(contentPath.value).first()),
-  {
-    getCachedData(key, nuxtApp) {
-      const cached = nuxtApp.payload.data[key]
-      return cached?.body ? cached : undefined
-    },
-  },
-)
+const { data: page } = await useAsyncData(contentPath.value, () => {
+  return queryLocalisedCollection((builder) => builder.path(contentPath.value).first())
+}, { watch: [contentPath] })
 </script>
 
 <template>
-  <ContentRenderer v-if="page?.body" :value="page" />
+  <ContentRenderer v-if="page" :value="page" />
   <div v-else class="container">
     <div class="mx-auto py-6 lg:py-8 prose dark:prose-invert">
       <DocsNotFound />

--- a/apps/docs/pages/util/[...slug].vue
+++ b/apps/docs/pages/util/[...slug].vue
@@ -7,7 +7,7 @@ const queryLocalisedCollection = useLocalisedCollection()
 const contentPath = useContentPath()
 
 const { data: page } = await useAsyncData(
-  () => contentPath.value,
+  contentPath.value,
   () => queryLocalisedCollection((builder) => builder.path(contentPath.value).first()),
   {
     getCachedData(key, nuxtApp) {


### PR DESCRIPTION
## Summary
Introduces a new `useContentPath()` composable to properly handle the mismatch between URL paths (which omit the locale prefix for the default locale) and content collection paths (which always include the locale prefix). This ensures consistent content queries across all components regardless of the current locale.

## Key Changes
- **New composable `useContentPath()`**: Bridges the gap between route paths and locale-prefixed content paths. The @nuxt/content collections store content under locale-prefixed paths (e.g., `/en/sandbox/setup`), but @nuxtjs/i18n serves the default locale without a URL prefix (e.g., `/sandbox/setup`). This composable automatically adds the locale prefix when needed.

- **Updated SideBar.vue**: 
  - Replaced direct route.path usage with `useContentPath()`
  - Added `localPath` computed property to strip locale prefix for hierarchy calculations
  - Added `toContentPath()` helper to re-add locale prefix for DB queries
  - Ensures path-based navigation works correctly regardless of locale

- **Updated Breadcrumb.vue**: 
  - Switched from `route.value.path` to `contentPath.value`
  - Filters out the bare locale root from breadcrumb segments
  - Updated watch dependency to track `contentPath` instead of route path

- **Updated TOCResponsive.vue, docs.vue, and page components**: 
  - Replaced `route.value.path` with `contentPath.value` for all content queries
  - Updated `useAsyncData()` watch dependencies to use `contentPath`
  - Ensures table of contents and page content load correctly for all locales

- **Updated NotFound.vue**: 
  - Uses `useContentPath()` for collection queries
  - Added watch dependency to reactively update when content path changes

## Implementation Details
The solution maintains backward compatibility while fixing locale handling by:
1. Computing the locale-prefixed path once via the composable
2. Using this computed path consistently across all content queries
3. Properly watching the computed path for reactivity instead of the raw route path

https://claude.ai/code/session_01KPiV6fEzjZVT71hGLoLQpP