### PR TITLE
Fix navigation tree traversal for 404 pages with intermediate dirs

### DIFF
--- a/apps/docs/components/docs/not-found/NotFound.vue
+++ b/apps/docs/components/docs/not-found/NotFound.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { ContentNavigationItem } from '@nuxt/content'
 import { fallbackTitleKey } from '~/utils/fallbackTitleKey'
 
 const { t } = useI18n()
@@ -7,21 +8,40 @@ const pathParts = computed(() => route.value.path.split('/'))
 
 const titleKey = computed(() => fallbackTitleKey(pathParts.value))
 
+// Query at section depth (path[:3]) rather than the full route path.
+// This keeps intermediate directory nodes that have an explicit index.md
+// (e.g. /sandbox/api-reference) present in the navigation tree even when
+// the LIKE filter is narrowed to a deeper sub-path. Without this, those
+// nodes are excluded from the SQLite result set and Nuxt Content drops them
+// from the tree, making the old fixed-depth [0] traversal skip a level.
+const sectionPath = computed(() => pathParts.value.slice(0, 3).join('/'))
+
 const queryLocalisedCollectionNavigation = useLocalisedCollectionNavigation()
 
-const { data: result } = await useAsyncData(() =>
-  queryLocalisedCollectionNavigation((builder) =>
-    builder.where('path', 'LIKE', `${route.value.path}%`),
-  ),
+const { data: result } = await useAsyncData(
+  () => `not-found-nav-${sectionPath.value}`,
+  () =>
+    queryLocalisedCollectionNavigation((builder) =>
+      builder.where('path', 'LIKE', `${sectionPath.value}%`),
+    ),
 )
 
-const list = computed(() => {
-  let current = result.value
-  for (let i = 0; i < pathParts.value.length - 1; i++) {
-    current = current?.[0]?.children
+const findChildren = (
+  items: ContentNavigationItem[] | null | undefined,
+  targetPath: string,
+): ContentNavigationItem[] | undefined => {
+  if (!Array.isArray(items)) return undefined
+  for (const item of items) {
+    if (item.path === targetPath) return item.children
+    if (item.children && targetPath.startsWith(item.path + '/')) {
+      const found = findChildren(item.children, targetPath)
+      if (found !== undefined) return found
+    }
   }
-  return current
-})
+  return undefined
+}
+
+const list = computed(() => findChildren(result.value, route.value.path))
 </script>
 
 <template>


### PR DESCRIPTION
## Summary
Fixes a bug in the NotFound component where navigation tree traversal would skip levels when intermediate directory nodes (e.g., `/sandbox/api-reference`) had explicit `index.md` files but the current route was deeper in the tree.

## Key Changes
- **Query scope adjustment**: Changed the Nuxt Content query from using the full route path to querying at section depth (`path[:3]`). This ensures intermediate directory nodes remain in the SQLite result set and aren't dropped by Nuxt Content's tree building logic.
- **Traversal algorithm**: Replaced fixed-depth array indexing (`current?.[0]?.children`) with a recursive `findChildren()` function that properly searches the navigation tree by matching exact path segments, handling cases where the tree structure doesn't follow a predictable depth pattern.
- **Cache key**: Added explicit async data key (`not-found-nav-${sectionPath.value}`) to prevent stale cache issues when navigating between routes at different depths.

## Implementation Details
The root cause was that querying with a deep path like `/sandbox/api-reference/some-page` would exclude the `/sandbox/api-reference` node from the SQLite LIKE filter results if it only matched deeper paths. The old code assumed a fixed tree depth and always accessed `[0]`, which failed when intermediate nodes were missing. The new recursive search traverses the actual tree structure returned by the query, making it resilient to varying depths and intermediate directory configurations.

https://claude.ai/code/session_01WNjKpagGL23LSQMAi4ARt2