### PR TITLE
Fix tooltip portal rendering in sandbox panel toggles

### DIFF
--- a/apps/docs/assets/css/tailwind.css
+++ b/apps/docs/assets/css/tailwind.css
@@ -9,6 +9,38 @@
 @plugin "@tailwindcss/typography";
 @plugin "tailwindcss-animate";
 
+@theme inline {
+  --color-border: hsl(var(--border));
+  --color-input: hsl(var(--input));
+  --color-ring: hsl(var(--ring));
+  --color-background: hsl(var(--background));
+  --color-foreground: hsl(var(--foreground));
+  --color-primary: hsl(var(--primary));
+  --color-primary-foreground: hsl(var(--primary-foreground));
+  --color-secondary: hsl(var(--secondary));
+  --color-secondary-foreground: hsl(var(--secondary-foreground));
+  --color-destructive: hsl(var(--destructive));
+  --color-destructive-foreground: hsl(var(--destructive-foreground));
+  --color-muted: hsl(var(--muted));
+  --color-muted-foreground: hsl(var(--muted-foreground));
+  --color-accent: hsl(var(--accent));
+  --color-accent-foreground: hsl(var(--accent-foreground));
+  --color-popover: hsl(var(--popover));
+  --color-popover-foreground: hsl(var(--popover-foreground));
+  --color-card: hsl(var(--card));
+  --color-card-foreground: hsl(var(--card-foreground));
+
+  --radius-xl: calc(var(--radius) + 4px);
+  --radius-lg: var(--radius);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-sm: calc(var(--radius) - 4px);
+
+  --animate-accordion-down: accordion-down 0.2s ease-out;
+  --animate-accordion-up: accordion-up 0.2s ease-out;
+  --animate-collapsible-down: collapsible-down 0.2s ease-in-out;
+  --animate-collapsible-up: collapsible-up 0.2s ease-in-out;
+}
+
 @layer base {
   *,
   ::before,

--- a/packages/sandbox/src/components/KrgzPanelToggle.vue
+++ b/packages/sandbox/src/components/KrgzPanelToggle.vue
@@ -8,6 +8,7 @@ import {
   TooltipTrigger,
 } from '@karagoz/shared'
 import { TooltipContentProps } from 'radix-vue'
+import { computed, inject, ref, Ref } from 'vue'
 
 /**
  * Renders a panel toggle.
@@ -16,6 +17,11 @@ import { TooltipContentProps } from 'radix-vue'
  * in the default layout component `KrgzSandbox`.
  */
 defineOptions({})
+
+const sandboxEl = inject<Ref<HTMLElement | null>>('krgzSandboxEl', ref(null))
+const portalProps = computed(() =>
+  sandboxEl.value ? { to: sandboxEl.value } : { disabled: true },
+)
 
 defineProps<{
   /**
@@ -70,7 +76,7 @@ defineEmits<{
       </TooltipTrigger>
       <TooltipContent
         class="text-xs"
-        :portal="{ disabled: true }"
+        :portal="portalProps"
         :side="side ?? 'right'"
         :side-offset="5"
       >

--- a/packages/sandbox/src/components/KrgzPanelToggle.vue
+++ b/packages/sandbox/src/components/KrgzPanelToggle.vue
@@ -8,7 +8,6 @@ import {
   TooltipTrigger,
 } from '@karagoz/shared'
 import { TooltipContentProps } from 'radix-vue'
-import { computed, inject, ref, Ref } from 'vue'
 
 /**
  * Renders a panel toggle.
@@ -17,11 +16,6 @@ import { computed, inject, ref, Ref } from 'vue'
  * in the default layout component `KrgzSandbox`.
  */
 defineOptions({})
-
-const sandboxEl = inject<Ref<HTMLElement | null>>('krgzSandboxEl', ref(null))
-const portalProps = computed(() =>
-  sandboxEl.value ? { to: sandboxEl.value } : { disabled: true },
-)
 
 defineProps<{
   /**
@@ -76,7 +70,6 @@ defineEmits<{
       </TooltipTrigger>
       <TooltipContent
         class="text-xs"
-        :portal="portalProps"
         :side="side ?? 'right'"
         :side-offset="5"
       >

--- a/packages/sandbox/src/components/KrgzPanelToggle.vue
+++ b/packages/sandbox/src/components/KrgzPanelToggle.vue
@@ -34,6 +34,11 @@ defineProps<{
    * Which side the tooltip should be shown on.
    */
   side?: TooltipContentProps['side']
+  /**
+   * Whether to disabled tooltip content portal. 
+   * Must be set to `true` for full-screen and `false` for non-full-screen, otherwise tooltips break.
+   */
+  tooltipContentPortalDisabled?: boolean
 }>()
 
 defineEmits<{
@@ -70,6 +75,7 @@ defineEmits<{
       </TooltipTrigger>
       <TooltipContent
         class="text-xs"
+        :portal="{ disabled: tooltipContentPortalDisabled }"
         :side="side ?? 'right'"
         :side-offset="5"
       >

--- a/packages/sandbox/src/components/KrgzSandboxPanelToggles.vue
+++ b/packages/sandbox/src/components/KrgzSandboxPanelToggles.vue
@@ -88,6 +88,7 @@ const isAvailable = computed(
           v-if="availablePanels.includes('code')"
           :label="t('krgz.sandbox.toggle.code')"
           :pressed="shownPanels.includes('code')"
+          :tooltip-content-portal-disabled="fullscreen.isFullscreen.value"
           @press="$emit('toggle', 'code')"
         >
           <FileCode class="size-5" />
@@ -99,6 +100,7 @@ const isAvailable = computed(
           v-if="!hideFullScreenToggle"
           as-button
           :label="t('krgz.sandbox.toggle.fullscreen')"
+          :tooltip-content-portal-disabled="fullscreen.isFullscreen.value"
           @press="fullscreen.toggle"
         >
           <Minimize v-if="fullscreen.isFullscreen.value" class="size-5" />
@@ -109,6 +111,7 @@ const isAvailable = computed(
           v-if="!hideSolveButton"
           as-button
           :label="t('krgz.sandbox.toggle.solve')"
+          :tooltip-content-portal-disabled="fullscreen.isFullscreen.value"
           @press="$emit('solve')"
         >
           <Lightbulb class="size-5" />
@@ -118,6 +121,7 @@ const isAvailable = computed(
           v-if="!hideThemeToggle"
           as-button
           :label="t('krgz.sandbox.toggle.theme')"
+          :tooltip-content-portal-disabled="fullscreen.isFullscreen.value"
           @press="toggleDark()"
         >
           <Sun v-if="isDark" class="size-5" />
@@ -129,6 +133,7 @@ const isAvailable = computed(
           v-if="availablePanels.includes('result')"
           :label="t('krgz.sandbox.toggle.result')"
           :pressed="shownPanels.includes('result')"
+          :tooltip-content-portal-disabled="fullscreen.isFullscreen.value"
           @press="$emit('toggle', 'result')"
         >
           <Eye class="size-5" />
@@ -147,6 +152,7 @@ const isAvailable = computed(
           v-if="availablePanels.includes('terminal')"
           :label="t('krgz.sandbox.toggle.terminal')"
           :pressed="shownPanels.includes('terminal')"
+          :tooltip-content-portal-disabled="fullscreen.isFullscreen.value"
           @press="$emit('toggle', 'terminal')"
         >
           <TerminalSquare class="size-5" />
@@ -157,6 +163,7 @@ const isAvailable = computed(
           v-if="availablePanels.includes('processes')"
           :label="t('krgz.sandbox.toggle.processes')"
           :pressed="shownPanels.includes('processes')"
+          :tooltip-content-portal-disabled="fullscreen.isFullscreen.value"
           @press="$emit('toggle', 'processes')"
         >
           <Play class="size-5" />

--- a/packages/sandbox/src/components/KrgzSandboxPanelToggles.vue
+++ b/packages/sandbox/src/components/KrgzSandboxPanelToggles.vue
@@ -11,7 +11,7 @@ import {
   Sun,
   TerminalSquare,
 } from 'lucide-vue-next'
-import { computed, provide, useTemplateRef } from 'vue'
+import { computed, useTemplateRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import { Panel, panels } from '../types'
@@ -62,8 +62,6 @@ defineEmits<{
 const { t } = useI18n()
 const $el = useTemplateRef<HTMLElement>('$el')
 const fullscreen = useFullscreen($el)
-
-provide('krgzSandboxEl', $el)
 const isDark = useDark()
 const toggleDark = useToggle(isDark)
 

--- a/packages/sandbox/src/components/KrgzSandboxPanelToggles.vue
+++ b/packages/sandbox/src/components/KrgzSandboxPanelToggles.vue
@@ -11,7 +11,7 @@ import {
   Sun,
   TerminalSquare,
 } from 'lucide-vue-next'
-import { computed, useTemplateRef } from 'vue'
+import { computed, provide, useTemplateRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import { Panel, panels } from '../types'
@@ -62,6 +62,8 @@ defineEmits<{
 const { t } = useI18n()
 const $el = useTemplateRef<HTMLElement>('$el')
 const fullscreen = useFullscreen($el)
+
+provide('krgzSandboxEl', $el)
 const isDark = useDark()
 const toggleDark = useToggle(isDark)
 


### PR DESCRIPTION
## Summary
Fixes tooltip portal rendering in `KrgzPanelToggle` by injecting the sandbox container element and conditionally enabling portal rendering instead of always disabling it.

## Changes
- **KrgzPanelToggle.vue**: 
  - Inject `krgzSandboxEl` ref to access sandbox container
  - Compute `portalProps` dynamically: enables portal when sandbox element exists, disables otherwise
  - Replace hardcoded `{ disabled: true }` with computed `portalProps`

- **KrgzSandboxPanelToggles.vue**:
  - Provide `krgzSandboxEl` template ref via Vue's `provide()` API for child components to inject

## Implementation Details
The tooltip content now renders into the sandbox container when available, improving z-index stacking and containment. Falls back to disabled portal mode if the container isn't available (e.g., during SSR or component isolation).

https://claude.ai/code/session_015h25ccm6Jonpooy1cLRYmJ