### PR TITLE
Add line highlighting and scrolling to editor views

### DIFF
--- a/apps/docs/components/content/sandbox/demo/SandboxDemoHighlightLines.vue
+++ b/apps/docs/components/content/sandbox/demo/SandboxDemoHighlightLines.vue
@@ -1,0 +1,92 @@
+<script setup lang="ts">
+import {
+  KrgzSandbox,
+  provideWebContainer,
+  useSandbox,
+  useSandboxBoot,
+} from '@karagoz/sandbox'
+import { Button } from '@karagoz/shared'
+import type { FileSystemTree } from '@webcontainer/api'
+import { onBeforeUnmount, onMounted } from 'vue'
+
+const { boot, isBooting } = useSandboxBoot()
+provideWebContainer(boot)
+
+const sandbox = useSandbox()
+const buttonsDisabled = ref(true)
+
+const { data: snapshot } = await useFetch<FileSystemTree>(
+  '/api/snapshot/express',
+)
+
+onMounted(async () => {
+  if (!snapshot.value) return
+  // Ensure injected promise has been resolved
+  const container = await boot
+  // Continue initialisation
+  await container.mount(await snapshot.value)
+  await sandbox.bootstrap()
+  sandbox.editorTabs.open('./server.js')
+  buttonsDisabled.value = false
+})
+
+onBeforeUnmount(() => sandbox.container.value?.teardown())
+</script>
+
+<template>
+  <div class="flex flex-col h-full">
+    <div v-show="!isBooting" class="border-b flex flex-wrap gap-2 p-2">
+      <Button
+        :disabled="buttonsDisabled"
+        size="xs"
+        variant="secondary"
+        @click="sandbox.editorViews.highlightLines(6)"
+        >Highlight line 6</Button
+      >
+      <Button
+        :disabled="buttonsDisabled"
+        size="xs"
+        variant="secondary"
+        @click="sandbox.editorViews.highlightLines([11, 13])"
+        >Highlight lines 11-13</Button
+      >
+      <Button
+        :disabled="buttonsDisabled"
+        size="xs"
+        variant="secondary"
+        @click="
+          sandbox.editorViews.highlightLines([5, 7], './public/style.css')
+        "
+        >Highlight style.css lines 5-7</Button
+      >
+      <Button
+        :disabled="buttonsDisabled"
+        size="xs"
+        variant="secondary"
+        @click="sandbox.editorViews.scrollToLine(11)"
+        >Scroll to line 11</Button
+      >
+      <Button
+        :disabled="buttonsDisabled"
+        size="xs"
+        variant="secondary"
+        @click="sandbox.editorViews.clearHighlightedLines()"
+        >Clear current tab's highlights</Button
+      >
+      <Button
+        :disabled="buttonsDisabled"
+        size="xs"
+        variant="secondary"
+        @click="sandbox.editorViews.clearAllHighlightedLines()"
+        >Clear all highlights</Button
+      >
+    </div>
+    <div class="flex-grow">
+      <KrgzSandbox
+        :booting="isBooting"
+        hide-solve-button
+        multi-panel-from="xl"
+      ></KrgzSandbox>
+    </div>
+  </div>
+</template>

--- a/apps/docs/content/en/sandbox/3.handbook/7.highlighting-and-scrolling.md
+++ b/apps/docs/content/en/sandbox/3.handbook/7.highlighting-and-scrolling.md
@@ -1,0 +1,73 @@
+# Highlighting & Scrolling to Lines
+
+The `editorViews` property of the sandbox instance lets you draw attention to specific lines in the editor: highlight
+them, scroll them into view, or both.
+
+## Highlighting Lines
+
+```ts
+// highlight a single line in the currently focused tab
+sandbox.editorViews.highlightLines(6)
+
+// highlight an inclusive range of lines
+sandbox.editorViews.highlightLines([11, 13])
+```
+
+If you pass a file path, that file is opened (and focused, if not already) before the lines are highlighted.
+
+```ts
+sandbox.editorViews.highlightLines([5, 7], './public/style.css')
+```
+
+## Highlighting Multiple Ranges
+
+`highlightLines()` is additive: calling it again adds another highlighted range rather than replacing the previous
+one, so multiple disjoint ranges can be highlighted in the same editor at once.
+
+```ts
+sandbox.editorViews.highlightLines(1)
+sandbox.editorViews.highlightLines([11, 13])
+// both line 1 and lines 11-13 are now highlighted
+```
+
+## Clearing Highlights
+
+```ts
+// clear highlights in the currently focused tab
+sandbox.editorViews.clearHighlightedLines()
+
+// clear highlights in a specific file
+sandbox.editorViews.clearHighlightedLines('./public/style.css')
+
+// clear highlights across every open editor
+sandbox.editorViews.clearAllHighlightedLines()
+```
+
+`clearHighlightedLines()` is a no-op if the target file isn't currently open.
+
+## Scrolling To A Line
+
+```ts
+// scroll the currently focused tab so line 11 is centered in view
+sandbox.editorViews.scrollToLine(11)
+
+// open (if needed), focus and scroll a specific file
+sandbox.editorViews.scrollToLine(11, './server.js')
+```
+
+Highlighting and scrolling are independent — call either one without the other. This is also true when opening a
+file that isn't loaded yet: `highlightLines()` and `scrollToLine()` will each open and focus the target file on
+their own; you don't need to call `editorTabs.open()` first.
+
+## Additional Functionality
+
+You can learn more about additional `editorViews` functionality in the
+[API Reference](/sandbox/api-reference/functions/usesandbox#editorviews).
+
+Some of that is also demonstrated in the example below.
+
+[Full example code](https://github.com/frontendat/karagoz/blob/main/apps/docs/components/content/sandbox/demo/SandboxDemoHighlightLines.vue)
+
+::demo-runner
+:sandbox-demo-highlight-lines
+::

--- a/packages/sandbox/src/components/KrgzEditor.vue
+++ b/packages/sandbox/src/components/KrgzEditor.vue
@@ -4,11 +4,12 @@ import { languages } from '@codemirror/language-data'
 import { EditorState, Extension } from '@codemirror/state'
 import { EditorView } from '@codemirror/view'
 import { computedAsync, useDark, useDebounceFn } from '@vueuse/core'
-import { computed, ref, shallowRef, watch } from 'vue'
+import { computed, onBeforeUnmount, ref, shallowRef, watch } from 'vue'
 import { Codemirror } from 'vue-codemirror'
 
 import { useSandbox } from '../composables'
 import { codemirrorDefaultTheme } from '../utils/codemirror.ts'
+import { highlightExtension } from '../utils/codemirrorHighlight.ts'
 
 /**
  * Renders CodeMirror to edit the currently focused file in the editor tabs.
@@ -83,7 +84,9 @@ const theme = computed(
 )
 
 const extensions = computed(() =>
-  [langPack.value, ...theme.value].filter((ext): ext is Extension => !!ext),
+  [langPack.value, ...theme.value, ...highlightExtension].filter(
+    (ext): ext is Extension => !!ext,
+  ),
 )
 
 // Codemirror EditorView instance ref
@@ -96,7 +99,12 @@ const handleReady = ({
   container: HTMLDivElement
 }) => {
   view.value = editorView
+  if (props.path) sandbox.editorViews.registerView(props.path, editorView)
 }
+
+onBeforeUnmount(() => {
+  if (props.path) sandbox.editorViews.unregisterView(props.path)
+})
 </script>
 
 <template>

--- a/packages/sandbox/src/composables/index.ts
+++ b/packages/sandbox/src/composables/index.ts
@@ -1,5 +1,6 @@
 export { useSandbox } from './useSandbox'
 export { useSandboxBoot } from './useSandboxBoot'
 export { useSandboxEditorTabs } from './useSandboxEditorTabs'
+export { useSandboxEditorViews } from './useSandboxEditorViews'
 export { useSandboxProcessTabs } from './useSandboxProcessTabs'
 export { useSandboxTabs } from './useSandboxTabs'

--- a/packages/sandbox/src/composables/useSandbox.ts
+++ b/packages/sandbox/src/composables/useSandbox.ts
@@ -6,6 +6,7 @@ import type { SandboxOptions } from '../types/Sandbox.ts'
 import { strToCmd } from '../utils/strToCmd.ts'
 import { injectWebContainer } from '../utils/WebContainer.ts'
 import { useSandboxEditorTabs } from './useSandboxEditorTabs.ts'
+import { useSandboxEditorViews } from './useSandboxEditorViews.ts'
 import { useSandboxExplorer } from './useSandboxExplorer.ts'
 import { useSandboxProcessTabs } from './useSandboxProcessTabs.ts'
 
@@ -90,6 +91,7 @@ function useSandboxInternal() {
 
   const explorer = useSandboxExplorer(options)
   const editorTabs = useSandboxEditorTabs(options)
+  const editorViews = useSandboxEditorViews(editorTabs)
   const processTabs = useSandboxProcessTabs(options)
 
   /**
@@ -205,6 +207,11 @@ function useSandboxInternal() {
      * Editor tabs manager. Responsible for opening, focusing and closing editor tabs.
      */
     editorTabs,
+    /**
+     * Highlight and scroll to lines in the editor. See `highlightLines`, `scrollToLine`,
+     * `clearHighlightedLines` and `clearAllHighlightedLines`.
+     */
+    editorViews,
     /**
      * Provides matchers for different purposes.
      * The matchers use [ignore](https://www.npmjs.com/package/ignore) to determine whether a give path matches one

--- a/packages/sandbox/src/composables/useSandboxEditorViews.ts
+++ b/packages/sandbox/src/composables/useSandboxEditorViews.ts
@@ -1,0 +1,128 @@
+import { EditorView } from '@codemirror/view'
+import { until } from '@vueuse/core'
+import { nextTick, shallowReactive } from 'vue'
+
+import {
+  addHighlightRange,
+  clearHighlightRanges,
+} from '../utils/codemirrorHighlight.ts'
+import { useSandboxEditorTabs } from './useSandboxEditorTabs.ts'
+import { HighlightLines } from '../types'
+
+/**
+ * Registry of live CodeMirror `EditorView` instances, keyed by file path, plus methods to
+ * highlight and scroll to lines in those editors. An editor tab can be mounted (and thus
+ * registered here) without being the currently focused tab, since `KrgzEditorTabs` keeps all open
+ * editors alive and toggles their visibility.
+ */
+export const useSandboxEditorViews = (
+  editorTabs: ReturnType<typeof useSandboxEditorTabs>,
+) => {
+  const views: Map<string, EditorView> = shallowReactive(new Map())
+
+  /**
+   * Register a file path's `EditorView` instance. Called internally by `KrgzEditor` once
+   * CodeMirror is ready.
+   * @param path
+   * @param view
+   */
+  const registerView = (path: string, view: EditorView) => {
+    views.set(path, view)
+  }
+
+  /**
+   * Unregister a file path's `EditorView` instance. Called internally by `KrgzEditor` when the
+   * editor tab is closed.
+   * @param path
+   */
+  const unregisterView = (path: string) => {
+    views.delete(path)
+  }
+
+  const resolveTargetPath = (path?: string) => {
+    if (path) {
+      editorTabs.open(path)
+      return path
+    }
+    return editorTabs.current.value?.id
+  }
+
+  const getReadyView = async (path: string) => {
+    await until(() => views.has(path)).toBe(true)
+    // Let the tab's `v-show` toggle settle before CodeMirror measures the viewport.
+    await nextTick()
+    return views.get(path)
+  }
+
+  const lineRange = (
+    doc: EditorView['state']['doc'],
+    lines: HighlightLines,
+  ) => {
+    const [start, end] = Array.isArray(lines) ? lines : [lines, lines]
+    const clamp = (line: number) => Math.min(Math.max(line, 1), doc.lines)
+    return {
+      from: doc.line(clamp(start)).from,
+      to: doc.line(clamp(end)).to,
+    }
+  }
+
+  /**
+   * Highlight one or more lines in an editor. Repeated calls are additive, so multiple disjoint
+   * ranges can be highlighted at the same time. If `path` refers to a file that isn't open yet,
+   * it is opened and focused first.
+   * @param lines a single line number, or a `[from, to]` inclusive range.
+   * @param path file path of the editor to highlight in. Defaults to the currently focused tab.
+   */
+  const highlightLines = async (lines: HighlightLines, path?: string) => {
+    const targetPath = resolveTargetPath(path)
+    if (!targetPath) return
+    const view = await getReadyView(targetPath)
+    if (!view) return
+    view.dispatch({
+      effects: addHighlightRange.of(lineRange(view.state.doc, lines)),
+    })
+  }
+
+  /**
+   * Scroll a line into view, centering it vertically. If `path` refers to a file that isn't open
+   * yet, it is opened and focused first.
+   * @param line line number to scroll into view.
+   * @param path file path of the editor to scroll. Defaults to the currently focused tab.
+   */
+  const scrollToLine = async (line: number, path?: string) => {
+    const targetPath = resolveTargetPath(path)
+    if (!targetPath) return
+    const view = await getReadyView(targetPath)
+    if (!view) return
+    const { from } = lineRange(view.state.doc, line)
+    view.dispatch({ effects: EditorView.scrollIntoView(from, { y: 'center' }) })
+  }
+
+  /**
+   * Clear all highlighted lines in one editor. No-op if `path` isn't currently open.
+   * @param path file path of the editor to clear. Defaults to the currently focused tab.
+   */
+  const clearHighlightedLines = (path?: string) => {
+    const targetPath = path ?? editorTabs.current.value?.id
+    const view = targetPath ? views.get(targetPath) : undefined
+    view?.dispatch({ effects: clearHighlightRanges.of(null) })
+  }
+
+  /**
+   * Clear highlighted lines across every open editor, not just one path.
+   */
+  const clearAllHighlightedLines = () => {
+    for (const view of views.values()) {
+      view.dispatch({ effects: clearHighlightRanges.of(null) })
+    }
+  }
+
+  return {
+    registerView,
+    unregisterView,
+    highlightLines,
+    scrollToLine,
+    clearHighlightedLines,
+    clearAllHighlightedLines,
+  }
+}

--- a/packages/sandbox/src/types/Tabs.ts
+++ b/packages/sandbox/src/types/Tabs.ts
@@ -23,6 +23,11 @@ export type Tab<T = undefined> = {
 }
 
 /**
+ * A single line number, or a `[from, to]` inclusive range of line numbers.
+ */
+export type HighlightLines = number | [number, number]
+
+/**
  * Context information for an editor tab.
  */
 export type EditorTabContext = {

--- a/packages/sandbox/src/utils/codemirrorHighlight.ts
+++ b/packages/sandbox/src/utils/codemirrorHighlight.ts
@@ -1,0 +1,72 @@
+import { StateEffect, StateField } from '@codemirror/state'
+import { Decoration, DecorationSet, EditorView } from '@codemirror/view'
+
+/**
+ * Character range (document positions, not line numbers) to be highlighted.
+ */
+export type HighlightRange = {
+  from: number
+  to: number
+}
+
+/**
+ * Adds a highlighted range. Dispatching this effect multiple times accumulates ranges, allowing
+ * multiple disjoint highlighted regions to be visible at once.
+ */
+export const addHighlightRange = StateEffect.define<HighlightRange>()
+
+/**
+ * Removes all highlighted ranges from the editor.
+ */
+export const clearHighlightRanges = StateEffect.define()
+
+const highlightLineMark = Decoration.line({ class: 'krgz-cm-highlight-line' })
+
+const decorateRange = (
+  doc: EditorView['state']['doc'],
+  range: HighlightRange,
+) => {
+  const decorations = []
+  let pos = range.from
+  while (pos <= range.to) {
+    const line = doc.lineAt(pos)
+    decorations.push(highlightLineMark.range(line.from))
+    pos = line.to + 1
+  }
+  return decorations
+}
+
+/**
+ * State field tracking the set of currently highlighted line decorations. Populated via the
+ * `addHighlightRange` / `clearHighlightRanges` effects.
+ */
+export const highlightField = StateField.define<DecorationSet>({
+  create: () => Decoration.none,
+  update(decorations, tr) {
+    let value = decorations.map(tr.changes)
+    for (const effect of tr.effects) {
+      if (effect.is(addHighlightRange)) {
+        value = value.update({
+          add: decorateRange(tr.state.doc, effect.value),
+          sort: true,
+        })
+      } else if (effect.is(clearHighlightRanges)) {
+        value = Decoration.none
+      }
+    }
+    return value
+  },
+  provide: (field) => EditorView.decorations.from(field),
+})
+
+const highlightTheme = EditorView.baseTheme({
+  '.krgz-cm-highlight-line': {
+    backgroundColor: 'hsl(var(--accent) / 40%)',
+  },
+})
+
+/**
+ * CodeMirror extension enabling line highlighting. Add this to an editor's `extensions` to allow
+ * dispatching `addHighlightRange` / `clearHighlightRanges` effects against its `EditorView`.
+ */
+export const highlightExtension = [highlightField, highlightTheme]


### PR DESCRIPTION
## Summary
Adds line highlighting and scroll-to-line functionality to the sandbox editor, enabling interactive tutorials and walkthroughs to draw attention to specific code regions.

## Key Changes
- **New composable `useSandboxEditorViews`** — Registry of live CodeMirror `EditorView` instances with methods to:
  - `highlightLines(lines, path?)` — Highlight one or more lines (additive, supports multiple disjoint ranges)
  - `scrollToLine(line, path?)` — Scroll a line into view, centered vertically
  - `clearHighlightedLines(path?)` / `clearAllHighlightedLines()` — Clear highlights in one or all editors
  - Auto-opens/focuses target file if not already loaded
  
- **CodeMirror highlight extension** (`codemirrorHighlight.ts`) — State field + decorations for line highlighting with CSS theming (uses `--accent` color at 40% opacity)

- **KrgzEditor integration** — Registers/unregisters `EditorView` instances on mount/unmount, includes highlight extension in editor config

- **Documentation & demo** — Handbook page explaining the API with interactive demo component (`SandboxDemoHighlightLines.vue`) showing all methods in action

- **Type export** — New `HighlightLines` type (`number | [number, number]`) for single lines or inclusive ranges

## Implementation Details
- Views stored in a `shallowReactive` Map keyed by file path, allowing editors to be mounted without being focused (tabs stay alive)
- `getReadyView()` waits for tab visibility to settle before CodeMirror measures viewport, ensuring accurate scroll positioning
- `lineRange()` helper clamps line numbers to document bounds and converts to character positions for CodeMirror dispatch
- Highlight effects are additive; `clearHighlightRanges` resets to empty decoration set

https://claude.ai/code/session_01GFarFbfdRhMb5YukQ11xDb